### PR TITLE
Update debug dependency to avoid Regex DOS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buttercup",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -29,9 +29,9 @@
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -81,31 +81,24 @@
       "requires": {
         "extend": "3.0.1",
         "semver": "5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-        }
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
@@ -125,16 +118,29 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-escape-sequences": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
+      "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "collect-all": "0.2.1"
+      }
+    },
     "ansi-escapes": {
-      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
@@ -194,6 +200,15 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
+    "array-back": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "dev": true,
+      "requires": {
+        "typical": "2.6.1"
+      }
+    },
     "array-filter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
@@ -223,6 +238,28 @@
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
       "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true
+    },
+    "array-tools": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
+      "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
+      "dev": true,
+      "requires": {
+        "object-tools": "1.6.7",
+        "typical": "2.6.1"
+      },
+      "dependencies": {
+        "object-tools": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+          "dev": true,
+          "requires": {
+            "array-tools": "1.8.6",
+            "typical": "2.6.1"
+          }
+        }
+      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -257,6 +294,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -264,9 +307,9 @@
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -286,30 +329,24 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.14",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.14.tgz",
-      "integrity": "sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+      "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
     },
     "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -343,63 +380,6 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "babel-core": {
@@ -437,12 +417,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
         }
       }
     },
@@ -460,14 +434,6 @@
         "lodash": "4.17.4",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -503,14 +469,6 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -576,14 +534,6 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -710,14 +660,6 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -959,7 +901,7 @@
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -996,9 +938,17 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.5.1",
+        "browserslist": "2.9.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "babel-register": {
@@ -1014,20 +964,6 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -1035,7 +971,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
       },
       "dependencies": {
@@ -1057,14 +993,6 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babel-traverse": {
@@ -1092,12 +1020,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
         }
       }
     },
@@ -1111,14 +1033,6 @@
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "1.0.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "babylon": {
@@ -1188,6 +1102,37 @@
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
@@ -1195,9 +1140,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
       "dev": true
     },
     "bn.js": {
@@ -1339,22 +1284,22 @@
       }
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
-      "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
+      "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000748",
-        "electron-to-chromium": "1.3.26"
+        "caniuse-lite": "1.0.30000766",
+        "electron-to-chromium": "1.3.27"
       }
     },
     "buffer": {
@@ -1392,9 +1337,9 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
-      "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
@@ -1407,25 +1352,40 @@
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
         "rimraf": "2.6.2",
-        "ssri": "4.1.6",
+        "ssri": "5.0.0",
         "unique-filename": "1.1.0",
         "y18n": "3.2.1"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
+      }
+    },
+    "cache-point": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
+      "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "core-js": "2.5.1",
+        "feature-detect-es6": "1.3.1",
+        "fs-then-native": "1.0.2",
+        "mkdirp": "0.5.1"
       }
     },
     "caller-path": {
@@ -1474,9 +1434,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000748",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000748.tgz",
-      "integrity": "sha1-RMjW2lKtZaXXudyk7+vQvdmCugk=",
+      "version": "1.0.30000766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000766.tgz",
+      "integrity": "sha1-iglcxeuZI8JwCM5NDbI+ZaPiiEM=",
       "dev": true
     },
     "caseless": {
@@ -1484,6 +1444,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "catharsis": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "0.3.0"
+      }
     },
     "center-align": {
       "version": "0.1.3",
@@ -1504,37 +1473,6 @@
         "assertion-error": "1.0.2",
         "deep-eql": "0.1.3",
         "type-detect": "1.0.0"
-      },
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-          "dev": true
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
-            }
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-          "dev": true
-        }
       }
     },
     "chai-as-promised": {
@@ -1544,26 +1482,25 @@
       "dev": true,
       "requires": {
         "check-error": "1.0.2"
-      },
-      "dependencies": {
-        "check-error": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-          "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-          "dev": true
-        }
       }
     },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
@@ -1573,30 +1510,13 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
         "is-glob": "2.0.1",
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
       }
     },
     "chownr": {
@@ -1606,16 +1526,16 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "2.33.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.33.1.tgz",
-      "integrity": "sha512-KfCnemSlTADPhqtjQfYNWqeZn2+mL5JLHR7z+dqIQepJXWldzLaxFMKftJewp4Xuz1Z+msOhwnxdZsxQ6oXbTw==",
+      "version": "2.33.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.33.2.tgz",
+      "integrity": "sha512-etnQeM8Mqiys50ZB4IiuNqeB1WS2/EKFhVXwkPQ1qjzKMMAJUyrLjaRUcoZoHrbjGscnhBrWkRR+p3zcTGMhDg==",
       "dev": true,
       "requires": {
-        "extract-zip": "1.6.5",
+        "del": "3.0.0",
+        "extract-zip": "1.6.6",
         "kew": "0.7.0",
         "mkdirp": "0.5.1",
-        "request": "2.83.0",
-        "rimraf": "2.6.2"
+        "request": "2.83.0"
       }
     },
     "ci-info": {
@@ -1631,13 +1551,6 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "circular-json": {
@@ -1646,13 +1559,18 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "clean-yaml-object": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+      "dev": true
+    },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -1669,11 +1587,34 @@
       "requires": {
         "slice-ansi": "0.0.4",
         "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "2.1.0",
@@ -1684,12 +1625,20 @@
         "center-align": "0.1.3",
         "right-align": "0.1.3",
         "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        }
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
     },
     "co": {
       "version": "4.6.0",
@@ -1714,34 +1663,10 @@
         "request": "2.74.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
         "assert-plus": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "aws-sign2": {
@@ -1749,31 +1674,6 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "bl": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.0.6"
-          }
         },
         "boom": {
           "version": "2.10.1",
@@ -1790,43 +1690,6 @@
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
         "cryptiles": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -1836,122 +1699,27 @@
             "boom": "2.10.1"
           }
         },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
         "form-data": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "dev": true,
           "requires": {
-            "async": "2.5.0",
+            "async": "2.6.0",
             "combined-stream": "1.0.5",
             "mime-types": "2.1.17"
           },
           "dependencies": {
             "async": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-              "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+              "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+              "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
               "dev": true,
               "requires": {
                 "lodash": "4.17.4"
               }
             }
           }
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "dev": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "dev": true,
-          "requires": {
-            "is-property": "1.0.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "dev": true
         },
         "har-validator": {
           "version": "2.0.6",
@@ -1963,15 +1731,6 @@
             "commander": "2.9.0",
             "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
           }
         },
         "hawk": {
@@ -2003,178 +1762,11 @@
             "sshpk": "1.13.1"
           }
         },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "is-my-json-valid": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-          "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-          "dev": true,
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-          "dev": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "lcov-parse": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
         "qs": {
           "version": "6.2.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
           "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
           "dev": true
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
         },
         "request": {
           "version": "2.74.0",
@@ -2214,116 +1806,78 @@
             "hoek": "2.16.3"
           }
         },
-        "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
+        }
+      }
+    },
+    "collect-all": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
+      "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
+      "dev": true,
+      "requires": {
+        "stream-connect": "1.0.2",
+        "stream-via": "0.1.1",
+        "typical": "2.6.1"
+      },
+      "dependencies": {
+        "stream-connect": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+          "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
+            "array-back": "1.0.4"
+          }
+        }
+      }
+    },
+    "collect-json": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
+      "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
+      "dev": true,
+      "requires": {
+        "collect-all": "1.0.3",
+        "stream-connect": "1.0.2",
+        "stream-via": "1.0.4"
+      },
+      "dependencies": {
+        "collect-all": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+          "dev": true,
+          "requires": {
+            "stream-connect": "1.0.2",
+            "stream-via": "1.0.4"
           }
         },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+        "stream-connect": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+          "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "stream-via": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
           "dev": true
         }
       }
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -2335,11 +1889,35 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
+    },
+    "column-layout": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
+      "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "2.2.2",
+        "array-back": "1.0.4",
+        "collect-json": "1.0.8",
+        "command-line-args": "2.1.6",
+        "core-js": "2.5.1",
+        "deep-extend": "0.4.2",
+        "feature-detect-es6": "1.3.1",
+        "object-tools": "2.0.6",
+        "typical": "2.6.1",
+        "wordwrapjs": "1.2.1"
+      }
     },
     "combine-lists": {
       "version": "1.0.1",
@@ -2348,14 +1926,6 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "combined-stream": {
@@ -2366,10 +1936,99 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
+      "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "command-line-usage": "2.0.5",
+        "core-js": "2.5.1",
+        "feature-detect-es6": "1.3.1",
+        "find-replace": "1.0.3",
+        "typical": "2.6.1"
+      }
+    },
+    "command-line-tool": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
+      "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "2.2.2",
+        "array-back": "1.0.4",
+        "command-line-args": "3.0.5",
+        "command-line-usage": "3.0.8",
+        "feature-detect-es6": "1.3.1",
+        "typical": "2.6.1"
+      },
+      "dependencies": {
+        "command-line-args": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
+          "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.3.1",
+            "find-replace": "1.0.3",
+            "typical": "2.6.1"
+          }
+        },
+        "command-line-usage": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
+          "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "3.0.0",
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.3.1",
+            "table-layout": "0.3.0",
+            "typical": "2.6.1"
+          },
+          "dependencies": {
+            "ansi-escape-sequences": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
+              "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
+              "dev": true,
+              "requires": {
+                "array-back": "1.0.4"
+              }
+            }
+          }
+        }
+      }
+    },
+    "command-line-usage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
+      "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "2.2.2",
+        "array-back": "1.0.4",
+        "column-layout": "2.1.4",
+        "feature-detect-es6": "1.3.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "1.2.1"
+      }
+    },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "common-sequence": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
       "dev": true
     },
     "commondir": {
@@ -2412,6 +2071,28 @@
         "typedarray": "0.0.6"
       }
     },
+    "config-master": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/config-master/-/config-master-1.0.2.tgz",
+      "integrity": "sha1-ZrhtzuT/Jwotv4j2is7dUYQign8=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "object-tools": "1.6.7"
+      },
+      "dependencies": {
+        "object-tools": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+          "dev": true,
+          "requires": {
+            "array-tools": "1.8.6",
+            "typical": "2.6.1"
+          }
+        }
+      }
+    },
     "connect": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
@@ -2443,6 +2124,12 @@
       "requires": {
         "date-now": "0.1.4"
       }
+    },
+    "console-dope": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/console-dope/-/console-dope-0.3.6.tgz",
+      "integrity": "sha1-2G8Ku2okd55VtiiqXRcmT4Esxgw=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2488,8 +2175,9 @@
       }
     },
     "core-js": {
-      "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2510,30 +2198,186 @@
         "parse-json": "2.2.0",
         "pinkie-promise": "2.0.1",
         "require-from-string": "1.2.1"
+      }
+    },
+    "coveralls": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
       },
       "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true
         },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true
         },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "hoek": "2.16.3"
           }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.9.0",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true
         }
       }
+    },
+    "crc32": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
+      "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo="
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -2554,13 +2398,6 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "sha.js": "2.4.9"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "create-hmac": {
@@ -2574,13 +2411,6 @@
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
         "sha.js": "2.4.9"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "cross-spawn": {
@@ -2592,6 +2422,18 @@
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
       }
     },
     "cryptiles": {
@@ -2615,9 +2457,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -2629,7 +2471,8 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.5",
+        "randomfill": "1.0.3"
       }
     },
     "currently-unhandled": {
@@ -2698,19 +2541,98 @@
         "meow": "3.7.0"
       }
     },
-    "debug": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+    "ddata": {
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.28.tgz",
+      "integrity": "sha1-UxOPr6PwF0nqJFHRK2tt2d8dWx8=",
+      "dev": true,
       "requires": {
-        "ms": "0.7.2"
+        "array-back": "1.0.4",
+        "core-js": "2.5.1",
+        "handlebars": "3.0.3",
+        "marked": "0.3.6",
+        "object-get": "2.1.0",
+        "reduce-flatten": "1.0.1",
+        "string-tools": "1.0.0",
+        "test-value": "2.1.0"
       },
       "dependencies": {
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true,
+          "optional": true
+        },
+        "handlebars": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
+          "dev": true,
+          "requires": {
+            "optimist": "0.6.1",
+            "source-map": "0.1.43",
+            "uglify-js": "2.3.6"
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "test-value": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "0.2.10",
+            "optimist": "0.3.7",
+            "source-map": "0.1.43"
+          },
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wordwrap": "0.0.3"
+              }
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true,
+          "optional": true
         }
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
       }
     },
     "decamelize": {
@@ -2719,10 +2641,44 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deeper": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
+      "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -2734,59 +2690,33 @@
         "object-keys": "1.0.11"
       }
     },
+    "deflate-js": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
+      "integrity": "sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms="
+    },
     "degenerator": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "requires": {
-        "ast-types": "0.9.14",
+        "ast-types": "0.10.1",
         "escodegen": "1.9.0",
         "esprima": "3.1.3"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        }
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
+        "globby": "6.1.0",
         "is-path-cwd": "1.0.0",
         "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
         "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        }
       }
     },
     "delayed-stream": {
@@ -2841,6 +2771,30 @@
         "randombytes": "2.0.5"
       }
     },
+    "dmd": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
+      "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "command-line-tool": "0.5.2",
+        "common-sequence": "1.0.2",
+        "ddata": "0.1.28",
+        "file-set": "1.1.1",
+        "handlebars-array": "0.2.1",
+        "handlebars-comparison": "2.0.1",
+        "handlebars-json": "1.0.1",
+        "handlebars-regexp": "1.0.1",
+        "handlebars-string": "2.0.2",
+        "object-tools": "2.0.6",
+        "reduce-unique": "1.0.0",
+        "reduce-without": "1.0.1",
+        "stream-handlebars": "0.1.6",
+        "string-tools": "1.0.0",
+        "walk-back": "2.0.1"
+      }
+    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -2876,7 +2830,7 @@
       "requires": {
         "es6-promise": "4.1.1",
         "mime": "2.0.3",
-        "superagent": "3.7.0",
+        "superagent": "3.8.1",
         "superagent-proxy": "1.0.2"
       }
     },
@@ -2923,9 +2877,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.26",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz",
-      "integrity": "sha1-mWQnKUhhp02cfIK5Jg6jAejALWY=",
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "elegant-spinner": {
@@ -2961,6 +2915,14 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
@@ -2982,6 +2944,23 @@
         "debug": "2.3.3",
         "engine.io-parser": "1.3.2",
         "ws": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
       }
     },
     "engine.io-client": {
@@ -3002,6 +2981,23 @@
         "ws": "1.1.2",
         "xmlhttprequest-ssl": "1.5.3",
         "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
       }
     },
     "engine.io-parser": {
@@ -3028,14 +3024,6 @@
         "memory-fs": "0.4.1",
         "object-assign": "4.1.1",
         "tapable": "0.2.8"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "ent": {
@@ -3176,7 +3164,8 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
@@ -3189,13 +3178,6 @@
         "esutils": "2.0.2",
         "optionator": "0.8.2",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        }
       }
     },
     "escope": {
@@ -3218,11 +3200,11 @@
       "requires": {
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.3.3",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
         "es6-map": "0.1.5",
         "escope": "3.6.0",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "estraverse": "4.2.0",
         "estraverse-fb": "1.3.2",
         "esutils": "2.0.2",
@@ -3243,7 +3225,7 @@
         "pluralize": "1.2.1",
         "progress": "1.1.8",
         "require-uncached": "1.0.3",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "shelljs": "0.5.3",
         "strip-json-comments": "1.0.4",
         "table": "3.8.3",
@@ -3251,36 +3233,46 @@
         "user-home": "2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "restore-cursor": "1.0.1"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "globals": {
           "version": "8.18.0",
@@ -3288,53 +3280,88 @@
           "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
           "dev": true
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+        "inquirer": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.4",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
           }
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "number-is-nan": "1.0.1"
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esrecurse": {
       "version": "4.2.0",
@@ -3344,14 +3371,6 @@
       "requires": {
         "estraverse": "4.2.0",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
       }
     },
     "estraverse": {
@@ -3393,14 +3412,6 @@
         "split": "0.3.3",
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        }
       }
     },
     "eventemitter3": {
@@ -3412,6 +3423,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
     },
     "evp_bytestokey": {
@@ -3437,14 +3454,6 @@
         "p-finally": "1.0.0",
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        }
       }
     },
     "exit-hook": {
@@ -3526,15 +3535,8 @@
       "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "requires": {
         "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
+        "jschardet": "1.6.0",
         "tmp": "0.0.33"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        }
       }
     },
     "extglob": {
@@ -3544,35 +3546,27 @@
       "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        }
       }
     },
     "extract-zip": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
         "minimist": {
@@ -3589,25 +3583,24 @@
           "requires": {
             "minimist": "0.0.8"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -3624,28 +3617,21 @@
         "pend": "1.2.0"
       }
     },
-    "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+    "feature-detect-es6": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
+      "integrity": "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
+        "array-back": "1.0.4"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -3656,14 +3642,16 @@
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
+      }
+    },
+    "file-set": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
+      "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "glob": "7.1.2"
       }
     },
     "file-uri-to-path": {
@@ -3690,6 +3678,15 @@
         "repeat-string": "1.6.1"
       }
     },
+    "filter-where": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
+      "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
+      "dev": true,
+      "requires": {
+        "test-value": "1.1.0"
+      }
+    },
     "finalhandler": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
@@ -3713,6 +3710,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -3723,8 +3726,30 @@
       "dev": true,
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.0.0",
+        "make-dir": "1.1.0",
         "pkg-dir": "2.0.0"
+      }
+    },
+    "find-replace": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "test-value": "2.1.0"
+      },
+      "dependencies": {
+        "test-value": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
+          }
+        }
       }
     },
     "find-up": {
@@ -3746,6 +3771,43 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
+      },
+      "dependencies": {
+        "del": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
+          "requires": {
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "flush-write-stream": {
@@ -3779,6 +3841,44 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
+      "dev": true
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3793,6 +3893,15 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
       }
     },
     "formidable": {
@@ -3825,6 +3934,15 @@
         "null-check": "1.0.0"
       }
     },
+    "fs-then-native": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
+      "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
+      "dev": true,
+      "requires": {
+        "feature-detect-es6": "1.3.1"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -3844,14 +3962,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -4009,7 +4127,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -4053,6 +4170,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4198,7 +4321,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -4370,11 +4492,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -4582,7 +4706,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -4830,11 +4953,21 @@
       "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
       "requires": {
         "data-uri-to-buffer": "1.2.0",
-        "debug": "2.3.3",
+        "debug": "2.6.9",
         "extend": "3.0.1",
         "file-uri-to-path": "1.0.0",
         "ftp": "0.3.10",
         "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "getpass": {
@@ -4847,11 +4980,12 @@
       }
     },
     "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
+        "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "minimatch": "3.0.4",
@@ -4867,23 +5001,6 @@
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -4893,23 +5010,6 @@
       "dev": true,
       "requires": {
         "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
       }
     },
     "globals": {
@@ -4919,53 +5019,23 @@
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
         "array-union": "1.0.2",
-        "arrify": "1.0.1",
         "glob": "7.1.2",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
         }
       }
     },
@@ -4994,18 +5064,6 @@
       "requires": {
         "crc32": "0.2.2",
         "deflate-js": "0.2.3"
-      },
-      "dependencies": {
-        "crc32": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
-          "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo="
-        },
-        "deflate-js": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
-          "integrity": "sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms="
-        }
       }
     },
     "handlebars": {
@@ -5020,12 +5078,6 @@
         "uglify-js": "2.8.29"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -5034,40 +5086,54 @@
           "requires": {
             "amdefine": "1.0.1"
           }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+        }
+      }
+    },
+    "handlebars-array": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
+      "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
+      "dev": true,
+      "requires": {
+        "array-tools": "1.8.6"
+      }
+    },
+    "handlebars-comparison": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
+      "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
+      "dev": true,
+      "requires": {
+        "array-tools": "1.8.6"
+      }
+    },
+    "handlebars-json": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
+      "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
+      "dev": true
+    },
+    "handlebars-regexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
+      "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
+      "dev": true
+    },
+    "handlebars-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
+      "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
+      "dev": true,
+      "requires": {
+        "array-tools": "1.8.6",
+        "string-tools": "0.1.8"
+      },
+      "dependencies": {
+        "string-tools": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
+          "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
+          "dev": true
         }
       }
     },
@@ -5083,7 +5149,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -5097,10 +5163,11 @@
       }
     },
     "has-ansi": {
-      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary": {
@@ -5127,9 +5194,9 @@
       "dev": true
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "hash-base": {
@@ -5138,13 +5205,6 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "hash.js": {
@@ -5171,7 +5231,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.1.0"
       }
     },
     "hmac-drbg": {
@@ -5201,6 +5261,12 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "home-path": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
+      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -5215,7 +5281,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       }
     },
     "http-proxy": {
@@ -5242,8 +5308,18 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.3.3",
+        "debug": "2.6.9",
         "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "http-signature": {
@@ -5258,9 +5334,9 @@
       }
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "https-proxy-agent": {
@@ -5269,8 +5345,18 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.3.3",
+        "debug": "2.6.9",
         "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "husky": {
@@ -5344,105 +5430,23 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+      "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
       "requires": {
         "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
+        "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "figures": "1.7.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
         "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx": "4.1.0",
+        "string-width": "2.1.1",
         "strip-ansi": "3.0.1",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-width": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        }
       }
     },
     "interpret": {
@@ -5474,6 +5478,21 @@
         "debug": "2.3.3",
         "hash_file": "0.1.1",
         "pbkdf2": "3.0.14"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
       }
     },
     "ip": {
@@ -5497,9 +5516,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -5554,9 +5573,9 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
@@ -5569,21 +5588,17 @@
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -5687,8 +5702,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -5762,12 +5776,6 @@
         "wordwrap": "1.0.0"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
         "escodegen": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
@@ -5806,12 +5814,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -5836,12 +5838,6 @@
           "requires": {
             "has-flag": "1.0.0"
           }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
         }
       }
     },
@@ -5852,7 +5848,7 @@
       "dev": true,
       "requires": {
         "convert-source-map": "1.5.0",
-        "istanbul-lib-instrument": "1.8.0",
+        "istanbul-lib-instrument": "1.9.1",
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0"
       }
@@ -5864,9 +5860,9 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
-      "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
+      "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
       "dev": true,
       "requires": {
         "babel-generator": "6.26.0",
@@ -5876,6 +5872,14 @@
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
         "semver": "5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "jest-get-type": {
@@ -5890,7 +5894,7 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
@@ -5902,13 +5906,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -5916,10 +5920,10 @@
             "supports-color": "4.5.0"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
@@ -5947,7 +5951,21 @@
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
       }
+    },
+    "js2xmlparser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
+      "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -5957,9 +5975,191 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
+    },
+    "jsdoc-75lb": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
+      "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.4.7",
+        "catharsis": "0.8.9",
+        "escape-string-regexp": "1.0.5",
+        "espree": "3.1.7",
+        "js2xmlparser": "1.0.0",
+        "klaw": "1.3.1",
+        "marked": "0.3.6",
+        "mkdirp": "0.5.1",
+        "requizzle": "0.2.1",
+        "strip-json-comments": "2.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        },
+        "espree": {
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
+          "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
+          "dev": true,
+          "requires": {
+            "acorn": "3.3.0",
+            "acorn-jsx": "3.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-api": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
+      "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "cache-point": "0.3.4",
+        "collect-all": "1.0.3",
+        "core-js": "2.5.1",
+        "feature-detect-es6": "1.3.1",
+        "file-set": "1.1.1",
+        "jsdoc-75lb": "3.6.0",
+        "object-to-spawn-args": "1.1.1",
+        "promise.prototype.finally": "1.0.1",
+        "temp-path": "1.0.0",
+        "then-fs": "2.0.0",
+        "walk-back": "2.0.1"
+      },
+      "dependencies": {
+        "collect-all": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
+          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+          "dev": true,
+          "requires": {
+            "stream-connect": "1.0.2",
+            "stream-via": "1.0.4"
+          }
+        },
+        "stream-connect": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+          "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        },
+        "stream-via": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
+          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-parse": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
+      "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "2.2.2",
+        "array-tools": "2.0.9",
+        "collect-json": "1.0.8",
+        "command-line-args": "2.1.6",
+        "command-line-tool": "0.1.0",
+        "core-js": "2.5.1",
+        "feature-detect-es6": "1.3.1",
+        "file-set": "0.2.8",
+        "jsdoc-api": "1.2.4",
+        "object-tools": "2.0.6",
+        "stream-connect": "1.0.2",
+        "test-value": "1.1.0"
+      },
+      "dependencies": {
+        "array-tools": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
+          "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "2.2.2",
+            "array-back": "1.0.4",
+            "collect-json": "1.0.8",
+            "filter-where": "1.0.1",
+            "object-get": "2.1.0",
+            "reduce-extract": "1.0.0",
+            "reduce-flatten": "1.0.1",
+            "reduce-unique": "1.0.0",
+            "reduce-without": "1.0.1",
+            "sort-array": "1.1.2",
+            "test-value": "1.1.0"
+          }
+        },
+        "command-line-tool": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
+          "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
+          "dev": true,
+          "requires": {
+            "ansi-escape-sequences": "2.2.2",
+            "array-back": "1.0.4"
+          }
+        },
+        "file-set": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
+          "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
+          "dev": true,
+          "requires": {
+            "array-tools": "2.0.9",
+            "glob": "4.5.3"
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "stream-connect": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+          "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4"
+          }
+        }
+      }
     },
     "jsdoc-to-markdown": {
       "version": "1.2.1",
@@ -5975,1113 +6175,6 @@
         "jsdoc-parse": "1.2.7",
         "object-tools": "2.0.6",
         "stream-connect": "0.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "dev": true,
-          "requires": {
-            "acorn": "3.3.0"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-          "dev": true
-        },
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
-        },
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
-        },
-        "array-tools": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-          "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
-          "dev": true,
-          "requires": {
-            "object-tools": "1.6.7",
-            "typical": "2.6.1"
-          },
-          "dependencies": {
-            "object-tools": {
-              "version": "1.6.7",
-              "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-              "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-              "dev": true,
-              "requires": {
-                "array-tools": "1.8.6",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "asap": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-          "dev": true
-        },
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "cache-point": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
-          "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "core-js": "2.5.1",
-            "feature-detect-es6": "1.3.1",
-            "fs-then-native": "1.0.2",
-            "mkdirp": "0.5.1"
-          }
-        },
-        "catharsis": {
-          "version": "0.8.9",
-          "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-          "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
-          "dev": true,
-          "requires": {
-            "underscore-contrib": "0.3.0"
-          }
-        },
-        "collect-all": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
-          "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
-          "dev": true,
-          "requires": {
-            "stream-connect": "1.0.2",
-            "stream-via": "0.1.1",
-            "typical": "2.6.1"
-          },
-          "dependencies": {
-            "stream-connect": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-              "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4"
-              }
-            }
-          }
-        },
-        "collect-json": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-          "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
-          "dev": true,
-          "requires": {
-            "collect-all": "1.0.3",
-            "stream-connect": "1.0.2",
-            "stream-via": "1.0.4"
-          },
-          "dependencies": {
-            "collect-all": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-              "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-              "dev": true,
-              "requires": {
-                "stream-connect": "1.0.2",
-                "stream-via": "1.0.4"
-              }
-            },
-            "stream-connect": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-              "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4"
-              }
-            },
-            "stream-via": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-              "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-              "dev": true
-            }
-          }
-        },
-        "column-layout": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
-          "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "collect-json": "1.0.8",
-            "command-line-args": "2.1.6",
-            "core-js": "2.5.1",
-            "deep-extend": "0.4.2",
-            "feature-detect-es6": "1.3.1",
-            "object-tools": "2.0.6",
-            "typical": "2.6.1",
-            "wordwrapjs": "1.2.1"
-          }
-        },
-        "command-line-args": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "command-line-usage": "2.0.5",
-            "core-js": "2.5.1",
-            "feature-detect-es6": "1.3.1",
-            "find-replace": "1.0.3",
-            "typical": "2.6.1"
-          }
-        },
-        "command-line-tool": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
-          "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "command-line-args": "3.0.5",
-            "command-line-usage": "3.0.8",
-            "feature-detect-es6": "1.3.1",
-            "typical": "2.6.1"
-          },
-          "dependencies": {
-            "command-line-args": {
-              "version": "3.0.5",
-              "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-              "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1",
-                "find-replace": "1.0.3",
-                "typical": "2.6.1"
-              }
-            },
-            "command-line-usage": {
-              "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
-              "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
-              "dev": true,
-              "requires": {
-                "ansi-escape-sequences": "3.0.0",
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1",
-                "table-layout": "0.3.0",
-                "typical": "2.6.1"
-              },
-              "dependencies": {
-                "ansi-escape-sequences": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
-                  "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
-                  "dev": true,
-                  "requires": {
-                    "array-back": "1.0.4"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "command-line-usage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "column-layout": "2.1.4",
-            "feature-detect-es6": "1.3.1",
-            "typical": "2.6.1",
-            "wordwrapjs": "1.2.1"
-          }
-        },
-        "common-sequence": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-          "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "config-master": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/config-master/-/config-master-1.0.2.tgz",
-          "integrity": "sha1-ZrhtzuT/Jwotv4j2is7dUYQign8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "object-tools": "1.6.7"
-          },
-          "dependencies": {
-            "object-tools": {
-              "version": "1.6.7",
-              "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-              "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-              "dev": true,
-              "requires": {
-                "array-tools": "1.8.6",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "console-dope": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/console-dope/-/console-dope-0.3.6.tgz",
-          "integrity": "sha1-2G8Ku2okd55VtiiqXRcmT4Esxgw=",
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
-        "ddata": {
-          "version": "0.1.28",
-          "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.28.tgz",
-          "integrity": "sha1-UxOPr6PwF0nqJFHRK2tt2d8dWx8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "core-js": "2.5.1",
-            "handlebars": "3.0.3",
-            "marked": "0.3.6",
-            "object-get": "2.1.0",
-            "reduce-flatten": "1.0.1",
-            "string-tools": "1.0.0",
-            "test-value": "2.1.0"
-          },
-          "dependencies": {
-            "test-value": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-              "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true
-        },
-        "dmd": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
-          "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "command-line-tool": "0.5.2",
-            "common-sequence": "1.0.2",
-            "ddata": "0.1.28",
-            "file-set": "1.1.1",
-            "handlebars-array": "0.2.1",
-            "handlebars-comparison": "2.0.1",
-            "handlebars-json": "1.0.1",
-            "handlebars-regexp": "1.0.1",
-            "handlebars-string": "2.0.2",
-            "object-tools": "2.0.6",
-            "reduce-unique": "1.0.0",
-            "reduce-without": "1.0.1",
-            "stream-handlebars": "0.1.6",
-            "string-tools": "1.0.0",
-            "walk-back": "2.0.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "espree": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
-          "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
-          "dev": true,
-          "requires": {
-            "acorn": "3.3.0",
-            "acorn-jsx": "3.0.1"
-          }
-        },
-        "feature-detect-es6": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-          "integrity": "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4"
-          }
-        },
-        "file-set": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
-          "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "glob": "7.1.2"
-          }
-        },
-        "filter-where": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
-          "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
-          "dev": true,
-          "requires": {
-            "test-value": "1.1.0"
-          }
-        },
-        "find-replace": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-          "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "test-value": "2.1.0"
-          },
-          "dependencies": {
-            "test-value": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-              "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "fs-then-native": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
-          "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
-          "dev": true,
-          "requires": {
-            "feature-detect-es6": "1.3.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        },
-        "handlebars": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-          "dev": true,
-          "requires": {
-            "optimist": "0.6.1",
-            "source-map": "0.1.43",
-            "uglify-js": "2.3.6"
-          }
-        },
-        "handlebars-array": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
-          "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6"
-          }
-        },
-        "handlebars-comparison": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
-          "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6"
-          }
-        },
-        "handlebars-json": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
-          "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
-          "dev": true
-        },
-        "handlebars-regexp": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
-          "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
-          "dev": true
-        },
-        "handlebars-string": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
-          "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6",
-            "string-tools": "0.1.8"
-          },
-          "dependencies": {
-            "string-tools": {
-              "version": "0.1.8",
-              "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
-              "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
-              "dev": true
-            }
-          }
-        },
-        "home-path": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-          "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "js2xmlparser": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-          "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
-          "dev": true
-        },
-        "jsdoc-75lb": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
-          "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.4.7",
-            "catharsis": "0.8.9",
-            "escape-string-regexp": "1.0.5",
-            "espree": "3.1.7",
-            "js2xmlparser": "1.0.0",
-            "klaw": "1.3.1",
-            "marked": "0.3.6",
-            "mkdirp": "0.5.1",
-            "requizzle": "0.2.1",
-            "strip-json-comments": "2.0.1",
-            "taffydb": "2.6.2",
-            "underscore": "1.8.3"
-          }
-        },
-        "jsdoc-api": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
-          "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "cache-point": "0.3.4",
-            "collect-all": "1.0.3",
-            "core-js": "2.5.1",
-            "feature-detect-es6": "1.3.1",
-            "file-set": "1.1.1",
-            "jsdoc-75lb": "3.6.0",
-            "object-to-spawn-args": "1.1.1",
-            "promise.prototype.finally": "1.0.1",
-            "temp-path": "1.0.0",
-            "then-fs": "2.0.0",
-            "walk-back": "2.0.1"
-          },
-          "dependencies": {
-            "collect-all": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-              "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-              "dev": true,
-              "requires": {
-                "stream-connect": "1.0.2",
-                "stream-via": "1.0.4"
-              }
-            },
-            "stream-connect": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-              "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4"
-              }
-            },
-            "stream-via": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-              "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-              "dev": true
-            }
-          }
-        },
-        "jsdoc-parse": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
-          "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-tools": "2.0.9",
-            "collect-json": "1.0.8",
-            "command-line-args": "2.1.6",
-            "command-line-tool": "0.1.0",
-            "core-js": "2.5.1",
-            "feature-detect-es6": "1.3.1",
-            "file-set": "0.2.8",
-            "jsdoc-api": "1.2.4",
-            "object-tools": "2.0.6",
-            "stream-connect": "1.0.2",
-            "test-value": "1.1.0"
-          },
-          "dependencies": {
-            "array-tools": {
-              "version": "2.0.9",
-              "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
-              "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
-              "dev": true,
-              "requires": {
-                "ansi-escape-sequences": "2.2.2",
-                "array-back": "1.0.4",
-                "collect-json": "1.0.8",
-                "filter-where": "1.0.1",
-                "object-get": "2.1.0",
-                "reduce-extract": "1.0.0",
-                "reduce-flatten": "1.0.1",
-                "reduce-unique": "1.0.0",
-                "reduce-without": "1.0.1",
-                "sort-array": "1.1.2",
-                "test-value": "1.1.0"
-              }
-            },
-            "command-line-tool": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
-              "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
-              "dev": true,
-              "requires": {
-                "ansi-escape-sequences": "2.2.2",
-                "array-back": "1.0.4"
-              }
-            },
-            "file-set": {
-              "version": "0.2.8",
-              "resolved": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
-              "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
-              "dev": true,
-              "requires": {
-                "array-tools": "2.0.9",
-                "glob": "4.5.3"
-              }
-            },
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-              "dev": true,
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0"
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "stream-connect": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-              "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4"
-              }
-            }
-          }
-        },
-        "klaw": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "marked": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-          "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "object-get": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-          "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
-          "dev": true
-        },
-        "object-to-spawn-args": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-          "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
-          "dev": true
-        },
-        "object-tools": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-          "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-json": "1.0.8",
-            "object-get": "2.1.0",
-            "test-value": "1.1.0",
-            "typical": "2.6.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "dev": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "promise.prototype.finally": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
-          "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
-          "dev": true
-        },
-        "reduce-extract": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-          "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
-          "dev": true,
-          "requires": {
-            "test-value": "1.1.0"
-          }
-        },
-        "reduce-flatten": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-          "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-          "dev": true
-        },
-        "reduce-unique": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-          "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
-          "dev": true
-        },
-        "reduce-without": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-          "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
-          "dev": true,
-          "requires": {
-            "test-value": "2.1.0"
-          },
-          "dependencies": {
-            "test-value": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-              "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "requizzle": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-          "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
-          "dev": true,
-          "requires": {
-            "underscore": "1.6.0"
-          },
-          "dependencies": {
-            "underscore": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-              "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-              "dev": true
-            }
-          }
-        },
-        "sort-array": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
-          "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "object-get": "2.1.0",
-            "typical": "2.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "stream-connect": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-0.1.0.tgz",
-          "integrity": "sha1-AdLoRp1N66Sf+hyNB526Ffvrfyg=",
-          "dev": true
-        },
-        "stream-handlebars": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
-          "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
-          "dev": true,
-          "requires": {
-            "handlebars": "3.0.3",
-            "object-tools": "1.6.7"
-          },
-          "dependencies": {
-            "object-tools": {
-              "version": "1.6.7",
-              "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-              "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-              "dev": true,
-              "requires": {
-                "array-tools": "1.8.6",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "stream-via": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
-          "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
-          "dev": true
-        },
-        "string-tools": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-          "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        },
-        "table-layout": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
-          "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "core-js": "2.5.1",
-            "deep-extend": "0.4.2",
-            "feature-detect-es6": "1.3.1",
-            "typical": "2.6.1",
-            "wordwrapjs": "2.0.0"
-          },
-          "dependencies": {
-            "wordwrapjs": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-              "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
-              "dev": true,
-              "requires": {
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1",
-                "reduce-flatten": "1.0.1",
-                "typical": "2.6.1"
-              }
-            }
-          }
-        },
-        "taffydb": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-          "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-          "dev": true
-        },
-        "temp-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-          "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
-          "dev": true
-        },
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        },
-        "then-fs": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-          "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-          "dev": true,
-          "requires": {
-            "promise": "7.3.1"
-          }
-        },
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "0.0.3"
-              }
-            }
-          }
-        },
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "dev": true
-        },
-        "underscore-contrib": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-          "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-          "dev": true,
-          "requires": {
-            "underscore": "1.6.0"
-          },
-          "dependencies": {
-            "underscore": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-              "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-              "dev": true
-            }
-          }
-        },
-        "walk-back": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        },
-        "wordwrapjs": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
-          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
       }
     },
     "jsesc": {
@@ -7094,6 +6187,12 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
     "json-schema": {
@@ -7178,7 +6277,7 @@
       "integrity": "sha512-k5pBjHDhmkdaUccnC7gE3mBzZjcxyxYsYVaqiL2G5AqlfLyBO5nw2VdNK+O16cveEPd/gIOWULH7gkiYYwVNHg==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "3.4.7",
         "body-parser": "1.18.2",
         "chokidar": "1.7.0",
         "colors": "1.1.2",
@@ -7207,26 +6306,6 @@
         "useragent": "2.2.1"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -7312,15 +6391,15 @@
       }
     },
     "karma-webpack": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.5.tgz",
-      "integrity": "sha512-tb+P6rCNqPpVOzaDkNvuAX5gXJ/baGIFBSD/Pin1p1RTa3cookXxEc5wRkrLVA9acwEKvEq1TetGkOX1f8mf8A==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.6.tgz",
+      "integrity": "sha512-dcKvtiW00caWrceCKwIvlKwHQu8zI+e3zWZYDLk7kr7nl1lYSp8uP+8fQoBvRCnZiPUGuwU5Psm20NbEIn7KlA==",
       "dev": true,
       "requires": {
         "async": "0.9.2",
         "loader-utils": "0.2.17",
         "lodash": "3.10.1",
-        "source-map": "0.1.43",
+        "source-map": "0.5.7",
         "webpack-dev-middleware": "1.12.0"
       },
       "dependencies": {
@@ -7347,21 +6426,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
         }
       }
     },
@@ -7377,7 +6441,16 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
       }
     },
     "lazy-cache": {
@@ -7394,6 +6467,12 @@
       "requires": {
         "invert-kv": "1.0.0"
       }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
     },
     "leven": {
       "version": "2.1.0",
@@ -7417,7 +6496,7 @@
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "commander": "2.11.0",
         "cosmiconfig": "1.1.0",
         "execa": "0.8.0",
@@ -7439,13 +6518,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7453,17 +6532,32 @@
             "supports-color": "4.5.0"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
         },
         "supports-color": {
           "version": "4.5.0",
@@ -7490,54 +6584,24 @@
         "is-stream": "1.1.0",
         "listr-silent-renderer": "1.1.1",
         "listr-update-renderer": "0.2.0",
-        "listr-verbose-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
         "log-symbols": "1.0.2",
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.0",
+        "rxjs": "5.5.2",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
+            "object-assign": "4.1.1"
           }
         },
         "log-symbols": {
@@ -7548,21 +6612,6 @@
           "requires": {
             "chalk": "1.1.3"
           }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -7588,44 +6637,14 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
+            "object-assign": "4.1.1"
           }
         },
         "indent-string": {
@@ -7642,28 +6661,13 @@
           "requires": {
             "chalk": "1.1.3"
           }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
     "listr-verbose-renderer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz",
-      "integrity": "sha1-RNwBuww0oDxXIVTU0Izemx3FYg8=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -7672,73 +6676,62 @@
         "figures": "1.7.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
             "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "object-assign": "4.1.1"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
         "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "loader-runner": {
@@ -7769,7 +6762,8 @@
       }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
@@ -7840,13 +6834,19 @@
         "lodash.isarray": "3.0.4"
       }
     },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
       "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0"
+        "chalk": "2.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7855,13 +6855,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7869,10 +6869,10 @@
             "supports-color": "4.5.0"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
@@ -7896,11 +6896,30 @@
         "cli-cursor": "1.0.2"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
         }
       }
     },
@@ -7946,6 +6965,12 @@
         }
       }
     },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -7969,33 +6994,20 @@
       "requires": {
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        }
       }
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+      "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U="
     },
     "make-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
       }
     },
     "map-obj": {
@@ -8008,6 +7020,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
       "dev": true
     },
     "md5.js": {
@@ -8057,40 +7075,11 @@
         "readable-stream": "2.3.3"
       }
     },
-    "memory-streams": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.2.tgz",
-      "integrity": "sha1-Jz/3d6tg/sWZsRY1UlUoLMosUMI=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "meow": {
       "version": "3.7.0",
@@ -8108,102 +7097,6 @@
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
       }
     },
     "methods": {
@@ -8232,21 +7125,6 @@
         "regex-cache": "0.4.4"
       },
       "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -8315,8 +7193,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
       "version": "1.3.0",
@@ -8330,7 +7207,7 @@
         "flush-write-stream": "1.0.2",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
-        "pump": "1.0.2",
+        "pump": "1.0.3",
         "pumpify": "1.3.5",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
@@ -8372,15 +7249,6 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -8389,12 +7257,6 @@
           "requires": {
             "ms": "0.7.1"
           }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
         },
         "glob": {
           "version": "7.0.5",
@@ -8409,12 +7271,6 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -8453,15 +7309,14 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-      "dev": true
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -8483,44 +7338,24 @@
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
-      },
-      "dependencies": {
-        "encoding": {
-          "version": "0.1.12",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        }
       }
     },
     "node-libs-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
         "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
+        "browserify-zlib": "0.2.0",
         "buffer": "4.9.1",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
+        "crypto-browserify": "3.12.0",
         "domain-browser": "1.1.7",
         "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
         "process": "0.11.10",
         "punycode": "1.4.1",
@@ -8528,21 +7363,19 @@
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
         "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
+        "string_decoder": "1.0.3",
         "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
         "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
     },
     "nodeunit": {
       "version": "0.9.5",
@@ -8551,2355 +7384,6 @@
       "dev": true,
       "requires": {
         "tap": "7.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "clean-yaml-object": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-          "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-          "dev": true
-        },
-        "color-support": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-          "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "coveralls": {
-          "version": "2.13.3",
-          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-          "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
-          "dev": true,
-          "requires": {
-            "js-yaml": "3.6.1",
-            "lcov-parse": "0.0.10",
-            "log-driver": "1.2.5",
-            "minimist": "1.2.0",
-            "request": "2.79.0"
-          },
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-              "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-              "dev": true,
-              "requires": {
-                "argparse": "1.0.9",
-                "esprima": "2.7.3"
-              }
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "deeper": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
-          "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g=",
-          "dev": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "diff": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
-          "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "events-to-array": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-          "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "dev": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "dev": true,
-          "requires": {
-            "is-property": "1.0.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.11.0",
-            "is-my-json-valid": "2.16.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "is-my-json-valid": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-          "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-          "dev": true,
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-              "dev": true
-            }
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-          "dev": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "lcov-parse": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-          "dev": true
-        },
-        "log-driver": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "nyc": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/nyc/-/nyc-7.1.0.tgz",
-          "integrity": "sha1-jhSXHzoV0au+x6xhDvVMuInp/7Q=",
-          "dev": true,
-          "requires": {
-            "arrify": "1.0.1",
-            "caching-transform": "1.0.1",
-            "convert-source-map": "1.3.0",
-            "default-require-extensions": "1.0.0",
-            "find-cache-dir": "0.1.1",
-            "find-up": "1.1.2",
-            "foreground-child": "1.5.3",
-            "glob": "7.0.5",
-            "istanbul-lib-coverage": "1.0.0-alpha.4",
-            "istanbul-lib-hook": "1.0.0-alpha.4",
-            "istanbul-lib-instrument": "1.1.0-alpha.4",
-            "istanbul-lib-report": "1.0.0-alpha.3",
-            "istanbul-lib-source-maps": "1.0.0-alpha.10",
-            "istanbul-reports": "1.0.0-alpha.8",
-            "md5-hex": "1.3.0",
-            "micromatch": "2.3.11",
-            "mkdirp": "0.5.1",
-            "pkg-up": "1.0.0",
-            "resolve-from": "2.0.0",
-            "rimraf": "2.5.4",
-            "signal-exit": "3.0.0",
-            "spawn-wrap": "1.2.4",
-            "test-exclude": "1.1.0",
-            "yargs": "4.8.1",
-            "yargs-parser": "2.4.1"
-          },
-          "dependencies": {
-            "align-text": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.0.3",
-                "longest": "1.0.1",
-                "repeat-string": "1.5.4"
-              }
-            },
-            "amdefine": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "append-transform": {
-              "version": "0.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-flatten": "1.0.1"
-              }
-            },
-            "arr-flatten": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "async": {
-              "version": "1.5.2",
-              "bundled": true,
-              "dev": true
-            },
-            "babel-code-frame": {
-              "version": "6.11.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-runtime": "6.9.2",
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "2.0.0"
-              }
-            },
-            "babel-generator": {
-              "version": "6.11.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.9.2",
-                "babel-types": "6.11.1",
-                "detect-indent": "3.0.1",
-                "lodash": "4.13.1",
-                "source-map": "0.5.6"
-              }
-            },
-            "babel-messages": {
-              "version": "6.8.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-runtime": "6.9.2"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.9.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "core-js": "2.4.1",
-                "regenerator-runtime": "0.9.5"
-              }
-            },
-            "babel-template": {
-              "version": "6.9.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-runtime": "6.9.2",
-                "babel-traverse": "6.11.4",
-                "babel-types": "6.11.1",
-                "babylon": "6.8.4",
-                "lodash": "4.13.1"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.11.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-code-frame": "6.11.0",
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.9.2",
-                "babel-types": "6.11.1",
-                "babylon": "6.8.4",
-                "debug": "2.2.0",
-                "globals": "8.18.0",
-                "invariant": "2.2.1",
-                "lodash": "4.13.1"
-              }
-            },
-            "babel-types": {
-              "version": "6.11.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-runtime": "6.9.2",
-                "babel-traverse": "6.11.4",
-                "esutils": "2.0.2",
-                "lodash": "4.13.1",
-                "to-fast-properties": "1.0.2"
-              }
-            },
-            "babylon": {
-              "version": "6.8.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-runtime": "6.9.2"
-              }
-            },
-            "balanced-match": {
-              "version": "0.4.2",
-              "bundled": true,
-              "dev": true
-            },
-            "brace-expansion": {
-              "version": "1.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "0.4.2",
-                "concat-map": "0.0.1"
-              }
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
-              }
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "caching-transform": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "write-file-atomic": "1.1.4"
-              }
-            },
-            "camelcase": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "center-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.0"
-              }
-            },
-            "commondir": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "convert-source-map": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "core-js": {
-              "version": "2.4.1",
-              "bundled": true,
-              "dev": true
-            },
-            "cross-spawn": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "4.0.1",
-                "which": "1.2.10"
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "default-require-extensions": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "strip-bom": "2.0.0"
-              }
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0",
-                "repeating": "1.1.3"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "error-ex": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-arrayish": "0.2.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fill-range": "2.2.3"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fill-range": {
-              "version": "2.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.5",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.5.4"
-              }
-            },
-            "find-cache-dir": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "commondir": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pkg-dir": "1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "for-in": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "for-own": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "for-in": "0.1.5"
-              }
-            },
-            "foreground-child": {
-              "version": "1.5.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cross-spawn": "4.0.0",
-                "signal-exit": "3.0.0"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "get-caller-file": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "glob": {
-              "version": "7.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.5",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.2",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.0"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-glob": "2.0.1"
-              }
-            },
-            "globals": {
-              "version": "8.18.0",
-              "bundled": true,
-              "dev": true
-            },
-            "graceful-fs": {
-              "version": "4.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "handlebars": {
-              "version": "4.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.7.0"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.4.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "amdefine": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.0.0"
-              }
-            },
-            "has-flag": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "hosted-git-info": {
-              "version": "2.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "1.3.3",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "invariant": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "loose-envify": "1.2.0"
-              }
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-arrayish": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-buffer": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              }
-            },
-            "is-dotfile": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-finite": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.0"
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.0.3"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-utf8": {
-              "version": "0.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isexe": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            },
-            "istanbul-lib-coverage": {
-              "version": "1.0.0-alpha.4",
-              "bundled": true,
-              "dev": true
-            },
-            "istanbul-lib-hook": {
-              "version": "1.0.0-alpha.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "append-transform": "0.3.0"
-              }
-            },
-            "istanbul-lib-instrument": {
-              "version": "1.1.0-alpha.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "babel-generator": "6.11.4",
-                "babel-template": "6.9.0",
-                "babel-traverse": "6.11.4",
-                "babel-types": "6.11.1",
-                "babylon": "6.8.4",
-                "istanbul-lib-coverage": "1.0.0-alpha.4"
-              }
-            },
-            "istanbul-lib-report": {
-              "version": "1.0.0-alpha.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "async": "1.5.2",
-                "istanbul-lib-coverage": "1.0.0-alpha.4",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "rimraf": "2.5.4",
-                "supports-color": "3.1.2"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "1.0.0"
-                  }
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "1.0.0-alpha.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "istanbul-lib-coverage": "1.0.0-alpha.4",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.5.4",
-                "source-map": "0.5.6"
-              }
-            },
-            "istanbul-reports": {
-              "version": "1.0.0-alpha.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "handlebars": "4.0.5"
-              }
-            },
-            "js-tokens": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.3"
-              }
-            },
-            "lazy-cache": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "invert-kv": "1.0.0"
-              }
-            },
-            "load-json-file": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.4",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
-              }
-            },
-            "lodash": {
-              "version": "4.13.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.assign": {
-              "version": "4.0.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash.keys": "4.0.7",
-                "lodash.rest": "4.0.3"
-              }
-            },
-            "lodash.keys": {
-              "version": "4.0.7",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.rest": {
-              "version": "4.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "longest": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "loose-envify": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "js-tokens": "1.0.3"
-              },
-              "dependencies": {
-                "js-tokens": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "lru-cache": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.0.0"
-              }
-            },
-            "md5-hex": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "md5-o-matic": "0.1.1"
-              }
-            },
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.0",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.0.3",
-                "normalize-path": "2.0.1",
-                "object.omit": "2.0.0",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.3"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.6"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "bundled": true,
-              "dev": true
-            },
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "2.1.5",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "number-is-nan": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "object.omit": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "for-own": "0.1.4",
-                "is-extendable": "0.1.1"
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lcid": "1.0.0"
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.2",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "error-ex": "1.3.0"
-              }
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.4",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "1.1.2"
-              }
-            },
-            "pkg-up": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "1.1.2"
-              }
-            },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "randomatic": {
-              "version": "1.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-number": "2.1.0",
-                "kind-of": "3.0.3"
-              }
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.3.5",
-                "path-type": "1.1.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.9.5",
-              "bundled": true,
-              "dev": true
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
-              }
-            },
-            "repeat-element": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "repeat-string": {
-              "version": "1.5.4",
-              "bundled": true,
-              "dev": true
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-finite": "1.0.1"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "resolve-from": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "right-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4"
-              }
-            },
-            "rimraf": {
-              "version": "2.5.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "7.0.5"
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true,
-              "dev": true
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "bundled": true,
-              "dev": true
-            },
-            "spawn-wrap": {
-              "version": "1.2.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "foreground-child": "1.5.3",
-                "mkdirp": "0.5.1",
-                "os-homedir": "1.0.1",
-                "rimraf": "2.5.4",
-                "signal-exit": "2.1.2",
-                "which": "1.2.10"
-              },
-              "dependencies": {
-                "signal-exit": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-license-ids": "1.2.1"
-              }
-            },
-            "spdx-exceptions": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-exceptions": "1.0.5",
-                "spdx-license-ids": "1.2.1"
-              }
-            },
-            "spdx-license-ids": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.0.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.0.0"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "test-exclude": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arrify": "1.0.1",
-                "lodash.assign": "4.0.9",
-                "micromatch": "2.3.11",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "uglify-js": {
-              "version": "2.7.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
-                    "window-size": "0.1.0"
-                  }
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.2"
-              }
-            },
-            "which": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "1.1.2"
-              }
-            },
-            "which-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "wrap-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "1.0.1"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "write-file-atomic": {
-              "version": "1.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.4",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yargs": {
-              "version": "4.8.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.1",
-                "lodash.assign": "4.0.9",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.1",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "2.4.1"
-              },
-              "dependencies": {
-                "cliui": {
-                  "version": "3.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "string-width": "1.0.1",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.0.0"
-                  }
-                },
-                "window-size": {
-                  "version": "0.2.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "2.4.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "3.0.0",
-                "lodash.assign": "4.0.9"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "only-shallow": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
-          "integrity": "sha1-cc7O26kyS8BRiu8Q7AgNMkncJGU=",
-          "dev": true
-        },
-        "opener": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
-          "dev": true
-        },
-        "os-homedir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-          "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
-          }
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "stack-utils": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz",
-          "integrity": "sha1-lAy4L8z6hOj/Lz/fKT/ngBa+zNE=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tap": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/tap/-/tap-7.1.2.tgz",
-          "integrity": "sha1-36w+zxSshUe7rSW70Wzyw3Q/Zc8=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "clean-yaml-object": "0.1.0",
-            "color-support": "1.1.3",
-            "coveralls": "2.13.3",
-            "deeper": "2.1.0",
-            "foreground-child": "1.5.6",
-            "glob": "7.1.2",
-            "isexe": "1.1.2",
-            "js-yaml": "3.10.0",
-            "nyc": "7.1.0",
-            "only-shallow": "1.2.0",
-            "opener": "1.4.3",
-            "os-homedir": "1.0.1",
-            "readable-stream": "2.3.3",
-            "signal-exit": "3.0.2",
-            "stack-utils": "0.4.0",
-            "tap-mocha-reporter": "2.0.1",
-            "tap-parser": "2.2.3",
-            "tmatch": "2.0.1"
-          }
-        },
-        "tap-mocha-reporter": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-2.0.1.tgz",
-          "integrity": "sha1-xwMWFz1uOhbFjhupLV1s2N5YoS4=",
-          "dev": true,
-          "requires": {
-            "color-support": "1.1.3",
-            "debug": "2.3.3",
-            "diff": "1.4.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "js-yaml": "3.10.0",
-            "readable-stream": "2.3.3",
-            "tap-parser": "2.2.3",
-            "unicode-length": "1.0.3"
-          }
-        },
-        "tap-parser": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-2.2.3.tgz",
-          "integrity": "sha1-rebpbje/04zg8WLaBn80A08GiwE=",
-          "dev": true,
-          "requires": {
-            "events-to-array": "1.1.2",
-            "js-yaml": "3.10.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "tmatch": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-          "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "unicode-length": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
-          "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true
-            }
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        }
       }
     },
     "nopt": {
@@ -10919,7 +7403,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.0.3",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -10939,18 +7423,18 @@
       }
     },
     "npm-run-all": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.1.tgz",
-      "integrity": "sha512-qrmqqaJa+REbzUTIL/mHfTdgwz+gL1xUezY/ueyLa7GISZ4T3h0CH8D2r6AaZdCYN2unu7PzspP0ofpXla1ftg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.2.tgz",
+      "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "chalk": "2.2.0",
+        "chalk": "2.3.0",
         "cross-spawn": "5.1.0",
-        "memory-streams": "0.1.2",
+        "memorystream": "0.3.1",
         "minimatch": "3.0.4",
         "ps-tree": "1.1.0",
-        "read-pkg": "2.0.0",
+        "read-pkg": "3.0.0",
         "shell-quote": "1.6.1",
         "string.prototype.padend": "3.0.0"
       },
@@ -10961,13 +7445,13 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -10975,10 +7459,58 @@
             "supports-color": "4.5.0"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "supports-color": {
@@ -11007,7 +7539,7 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
+        "commander": "2.9.0",
         "npm-path": "2.0.3",
         "which": "1.3.0"
       }
@@ -11030,6 +7562,1421 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nyc": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-7.1.0.tgz",
+      "integrity": "sha1-jhSXHzoV0au+x6xhDvVMuInp/7Q=",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.3.0",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.3",
+        "glob": "7.0.5",
+        "istanbul-lib-coverage": "1.0.0-alpha.4",
+        "istanbul-lib-hook": "1.0.0-alpha.4",
+        "istanbul-lib-instrument": "1.1.0-alpha.4",
+        "istanbul-lib-report": "1.0.0-alpha.3",
+        "istanbul-lib-source-maps": "1.0.0-alpha.10",
+        "istanbul-reports": "1.0.0-alpha.8",
+        "md5-hex": "1.3.0",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "pkg-up": "1.0.0",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.4",
+        "signal-exit": "3.0.0",
+        "spawn-wrap": "1.2.4",
+        "test-exclude": "1.1.0",
+        "yargs": "4.8.1",
+        "yargs-parser": "2.4.1"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.0.3",
+            "longest": "1.0.1",
+            "repeat-string": "1.5.4"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.0.1"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.11.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.9.2",
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "2.0.0"
+          }
+        },
+        "babel-generator": {
+          "version": "6.11.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.8.0",
+            "babel-runtime": "6.9.2",
+            "babel-types": "6.11.1",
+            "detect-indent": "3.0.1",
+            "lodash": "4.13.1",
+            "source-map": "0.5.6"
+          }
+        },
+        "babel-messages": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.9.2"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.9.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.9.5"
+          }
+        },
+        "babel-template": {
+          "version": "6.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.9.2",
+            "babel-traverse": "6.11.4",
+            "babel-types": "6.11.1",
+            "babylon": "6.8.4",
+            "lodash": "4.13.1"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.11.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.11.0",
+            "babel-messages": "6.8.0",
+            "babel-runtime": "6.9.2",
+            "babel-types": "6.11.1",
+            "babylon": "6.8.4",
+            "debug": "2.2.0",
+            "globals": "8.18.0",
+            "invariant": "2.2.1",
+            "lodash": "4.13.1"
+          }
+        },
+        "babel-types": {
+          "version": "6.11.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.9.2",
+            "babel-traverse": "6.11.4",
+            "esutils": "2.0.2",
+            "lodash": "4.13.1",
+            "to-fast-properties": "1.0.2"
+          }
+        },
+        "babylon": {
+          "version": "6.8.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.9.2"
+          }
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.1.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.0"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.0.1",
+            "which": "1.2.10"
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "error-ex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.5",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.5.4"
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "for-in": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "0.1.5"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.0",
+            "signal-exit": "3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.2",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.7.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.3.3",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.2.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.0.3"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.0.0-alpha.4",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.0.0-alpha.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "0.3.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.1.0-alpha.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.11.4",
+            "babel-template": "6.9.0",
+            "babel-traverse": "6.11.4",
+            "babel-types": "6.11.1",
+            "babylon": "6.8.4",
+            "istanbul-lib-coverage": "1.0.0-alpha.4"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.0.0-alpha.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "istanbul-lib-coverage": "1.0.0-alpha.4",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "rimraf": "2.5.4",
+            "supports-color": "3.1.2"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.0.0-alpha.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.0.0-alpha.4",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.5.4",
+            "source-map": "0.5.6"
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.0.0-alpha.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.5"
+          }
+        },
+        "js-tokens": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.3"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.4",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.assign": {
+          "version": "4.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.keys": "4.0.7",
+            "lodash.rest": "4.0.3"
+          }
+        },
+        "lodash.keys": {
+          "version": "4.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.rest": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "1.0.3"
+          },
+          "dependencies": {
+            "js-tokens": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.0.0"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.3",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.6"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.1.5",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.4",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.2",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.4",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "kind-of": "3.0.3"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.5",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.9.5",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.5.4",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.1"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.0.5"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.3",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.1",
+            "rimraf": "2.5.4",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.1"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "1.0.5",
+            "spdx-license-ids": "1.2.1"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.0.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "lodash.assign": "4.0.9",
+            "micromatch": "2.3.11",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.2"
+          }
+        },
+        "which": {
+          "version": "1.2.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "1.1.2"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.4",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.1",
+            "lodash.assign": "4.0.9",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.1",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.1",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.0.0"
+              }
+            },
+            "window-size": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.0.9"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -11037,7 +8984,8 @@
       "dev": true
     },
     "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
@@ -11046,11 +8994,36 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-get": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
+      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object-to-spawn-args": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
+      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+      "dev": true
+    },
+    "object-tools": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
+      "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "collect-json": "1.0.8",
+        "object-get": "2.1.0",
+        "test-value": "1.1.0",
+        "typical": "2.6.1"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -11081,9 +9054,17 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "only-shallow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
+      "integrity": "sha1-cc7O26kyS8BRiu8Q7AgNMkncJGU=",
       "dev": true
     },
     "opencollective": {
@@ -11092,122 +9073,26 @@
       "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
       "requires": {
         "babel-polyfill": "6.23.0",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "chalk": "1.1.3",
         "inquirer": "3.0.6",
         "minimist": "1.2.0",
         "node-fetch": "1.6.3",
         "opn": "4.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "requires": {
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-          }
-        },
-        "inquirer": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-          "requires": {
-            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "cli-cursor": "2.1.0",
-            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-            "external-editor": "2.0.5",
-            "figures": "2.0.0",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx": "4.1.0",
-            "string-width": "2.1.1",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "requires": {
-            "is-promise": "2.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        }
       }
+    },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
     },
     "opn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "optimist": {
@@ -11217,13 +9102,19 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.10",
-        "wordwrap": "0.0.2"
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
       }
@@ -11239,13 +9130,6 @@
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2",
         "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        }
       }
     },
     "options": {
@@ -11266,73 +9150,37 @@
         "object-assign": "4.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "restore-cursor": "1.0.1"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
     "os-browserify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-homedir": {
@@ -11366,12 +9214,6 @@
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
           }
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
         }
       }
     },
@@ -11464,9 +9306,9 @@
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "parallel-transform": {
@@ -11486,7 +9328,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
+        "asn1.js": "4.9.2",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -11503,23 +9345,6 @@
         "is-dotfile": "1.0.3",
         "is-extglob": "1.0.0",
         "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
       }
     },
     "parse-json": {
@@ -11601,12 +9426,22 @@
       "dev": true
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "pause-stream": {
@@ -11616,14 +9451,6 @@
       "dev": true,
       "requires": {
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        }
       }
     },
     "pbkdf2": {
@@ -11651,20 +9478,22 @@
       "dev": true
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
-      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
-      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -11722,12 +9551,6 @@
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
           }
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
         }
       }
     },
@@ -11753,7 +9576,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -11781,10 +9604,25 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise.prototype.finally": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
+      "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
       "dev": true
     },
     "proxy-agent": {
@@ -11793,7 +9631,7 @@
       "integrity": "sha512-I23qaUnXmU/ItpXWQcMj9wMcZQTXnJNI7nakSR+q95Iht8H0+w3dCgTJdfnOQqOCX1FZwKLSgurCyEt11LM6OA==",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.3.3",
+        "debug": "2.6.9",
         "extend": "3.0.1",
         "http-proxy-agent": "1.0.0",
         "https-proxy-agent": "1.0.0",
@@ -11802,10 +9640,13 @@
         "socks-proxy-agent": "2.1.1"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-          "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U="
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -11844,9 +9685,9 @@
       }
     },
     "pump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
@@ -11861,7 +9702,7 @@
       "requires": {
         "duplexify": "3.5.1",
         "inherits": "2.0.3",
-        "pump": "1.0.2"
+        "pump": "1.0.3"
       }
     },
     "punycode": {
@@ -11918,7 +9759,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -11929,7 +9770,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -11940,6 +9781,16 @@
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "dev": true,
+      "requires": {
+        "randombytes": "2.0.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -11961,24 +9812,45 @@
       }
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
+        "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -12016,6 +9888,23 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -12035,6 +9924,48 @@
           "dev": true,
           "requires": {
             "get-stdin": "4.0.1"
+          }
+        }
+      }
+    },
+    "reduce-extract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
+      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "dev": true,
+      "requires": {
+        "test-value": "1.1.0"
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "dev": true
+    },
+    "reduce-unique": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
+      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
+      "dev": true
+    },
+    "reduce-without": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
+      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "dev": true,
+      "requires": {
+        "test-value": "2.1.0"
+      },
+      "dependencies": {
+        "test-value": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "1.0.4",
+            "typical": "2.6.1"
           }
         }
       }
@@ -12203,10 +10134,27 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -12219,13 +10167,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "right-align": {
@@ -12244,96 +10191,6 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
       }
     },
     "ripemd160": {
@@ -12343,22 +10200,14 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "once": "1.4.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-queue": {
@@ -12382,9 +10231,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.0.tgz",
-      "integrity": "sha512-vmvP5y/oJIJmXKHY36PIjVeI/46Sny6BMBa7/ou2zsNz1PiqU/Gtcz1GujnHz5Qlxncv+J9VlWmttnshqFj3Kg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.4"
@@ -12395,20 +10244,30 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "schema-utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3"
+        "ajv": "5.3.0"
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -12440,13 +10299,6 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "shebang-command": {
@@ -12483,7 +10335,8 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
@@ -12496,44 +10349,6 @@
         "lolex": "1.3.2",
         "samsam": "1.1.2",
         "util": "0.10.3"
-      },
-      "dependencies": {
-        "formatio": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-          "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-          "dev": true,
-          "requires": {
-            "samsam": "1.1.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        },
-        "lolex": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-          "dev": true
-        },
-        "samsam": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-          "dev": true
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.1"
-          }
-        }
       }
     },
     "slash": {
@@ -12554,9 +10369,9 @@
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
         "hoek": "4.2.0"
@@ -12577,6 +10392,21 @@
         "socket.io-parser": "2.3.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
         "object-assign": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
@@ -12593,6 +10423,23 @@
       "requires": {
         "debug": "2.3.3",
         "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
       }
     },
     "socket.io-client": {
@@ -12612,6 +10459,23 @@
         "parseuri": "0.0.5",
         "socket.io-parser": "2.3.1",
         "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
       }
     },
     "socket.io-parser": {
@@ -12674,6 +10538,17 @@
         "socks": "1.1.10"
       }
     },
+    "sort-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
+      "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "object-get": "2.1.0",
+        "typical": "2.6.1"
+      }
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -12722,14 +10597,6 @@
       "dev": true,
       "requires": {
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        }
       }
     },
     "sprintf-js": {
@@ -12755,13 +10622,19 @@
       }
     },
     "ssri": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
-      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
+    },
+    "stack-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz",
+      "integrity": "sha1-lAy4L8z6hOj/Lz/fKT/ngBa+zNE=",
+      "dev": true
     },
     "staged-git-files": {
       "version": "0.0.4",
@@ -12770,9 +10643,9 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -12793,6 +10666,12 @@
         "duplexer": "0.1.1"
       }
     },
+    "stream-connect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-0.1.0.tgz",
+      "integrity": "sha1-AdLoRp1N66Sf+hyNB526Ffvrfyg=",
+      "dev": true
+    },
     "stream-each": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -12801,6 +10680,86 @@
       "requires": {
         "end-of-stream": "1.4.0",
         "stream-shift": "1.0.0"
+      }
+    },
+    "stream-handlebars": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
+      "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
+      "dev": true,
+      "requires": {
+        "handlebars": "3.0.3",
+        "object-tools": "1.6.7"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true,
+          "optional": true
+        },
+        "handlebars": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+          "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
+          "dev": true,
+          "requires": {
+            "optimist": "0.6.1",
+            "source-map": "0.1.43",
+            "uglify-js": "2.3.6"
+          }
+        },
+        "object-tools": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
+          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
+          "dev": true,
+          "requires": {
+            "array-tools": "1.8.6",
+            "typical": "2.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "0.2.10",
+            "optimist": "0.3.7",
+            "source-map": "0.1.43"
+          },
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wordwrap": "0.0.3"
+              }
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "stream-http": {
@@ -12828,35 +10787,43 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
+    "stream-via": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
+      "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
+      "dev": true
+    },
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
+    "string-tools": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
+      "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
+      "dev": true
+    },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -12898,17 +10865,21 @@
       "dev": true
     },
     "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -12929,9 +10900,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
-      "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
+      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
@@ -12945,14 +10916,6 @@
         "readable-stream": "2.3.3"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
@@ -12965,12 +10928,23 @@
       "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.2.tgz",
       "integrity": "sha1-ktNmBXj2GO1DqCz4yseZ/ik4ui0=",
       "requires": {
-        "debug": "2.3.3",
+        "debug": "2.6.9",
         "proxy-agent": "2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symbol-observable": {
@@ -13002,107 +10976,121 @@
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
           }
-        },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-ansi": {
+        }
+      }
+    },
+    "table-layout": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
+      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "core-js": "2.5.1",
+        "deep-extend": "0.4.2",
+        "feature-detect-es6": "1.3.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "2.0.0"
+      },
+      "dependencies": {
+        "wordwrapjs": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
+          "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "array-back": "1.0.4",
+            "feature-detect-es6": "1.3.1",
+            "reduce-flatten": "1.0.1",
+            "typical": "2.6.1"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        }
+      }
+    },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
+    "tap": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-7.1.2.tgz",
+      "integrity": "sha1-36w+zxSshUe7rSW70Wzyw3Q/Zc8=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.4.7",
+        "clean-yaml-object": "0.1.0",
+        "color-support": "1.1.3",
+        "coveralls": "2.13.3",
+        "deeper": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "isexe": "1.1.2",
+        "js-yaml": "3.10.0",
+        "nyc": "7.1.0",
+        "only-shallow": "1.2.0",
+        "opener": "1.4.3",
+        "os-homedir": "1.0.1",
+        "readable-stream": "2.3.3",
+        "signal-exit": "3.0.2",
+        "stack-utils": "0.4.0",
+        "tap-mocha-reporter": "2.0.1",
+        "tap-parser": "2.2.3",
+        "tmatch": "2.0.1"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+        "os-homedir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+          "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
           "dev": true
         }
+      }
+    },
+    "tap-mocha-reporter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-2.0.1.tgz",
+      "integrity": "sha1-xwMWFz1uOhbFjhupLV1s2N5YoS4=",
+      "dev": true,
+      "requires": {
+        "color-support": "1.1.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "readable-stream": "2.3.3",
+        "tap-parser": "2.2.3",
+        "unicode-length": "1.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "tap-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-2.2.3.tgz",
+      "integrity": "sha1-rebpbje/04zg8WLaBn80A08GiwE=",
+      "dev": true,
+      "requires": {
+        "events-to-array": "1.1.2",
+        "js-yaml": "3.10.0",
+        "readable-stream": "2.3.3"
       }
     },
     "tapable": {
@@ -13111,14 +11099,40 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "temp-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
+      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "dev": true
+    },
+    "test-value": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+      "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "typical": "2.6.1"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "then-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
+      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
+      "dev": true,
+      "requires": {
+        "promise": "7.3.1"
+      }
+    },
     "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -13150,6 +11164,12 @@
       "requires": {
         "setimmediate": "1.0.5"
       }
+    },
+    "tmatch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
+      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -13234,6 +11254,12 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -13250,14 +11276,21 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-es": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.3.tgz",
-      "integrity": "sha512-Nuo5gkv/Q6PmLa+Ui2LvK+87YdMAcuXfRIWF0uVfkHVSfpT3Ue0euCSu4t0b8xv4Bt05lmXUT8bLI9OmnyPj8A==",
+    "typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.5.7"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -13268,18 +11301,44 @@
       "optional": true
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.0-beta.3.tgz",
-      "integrity": "sha512-4fpQrnoYEuzAwDxI2zLrKMgrknaWu71CpG4XaMRXWWyUJ7yBM4ueIhNNf0/AcKVSUgBpVudi1i9h9lWdfrU7ZQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha512-3IJhab8Xq7s6XqoPiVFuDpijefJsIrzACT4ggDErSxJAsB9GLDyuWpN7vuX4Lslu/nzIRz2NyXNX/fRMOgqRFw==",
       "dev": true,
       "requires": {
-        "cacache": "9.3.0",
+        "cacache": "10.0.1",
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
         "source-map": "0.5.7",
-        "uglify-es": "3.1.3",
-        "webpack-sources": "1.0.1",
-        "worker-farm": "1.5.0"
+        "uglify-es": "3.1.9",
+        "webpack-sources": "1.0.2",
+        "worker-farm": "1.5.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "uglify-es": {
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.9.tgz",
+          "integrity": "sha512-wVSiJKHDgDDFmxTVVvnbAH6IpamAFHYDI+5JvwPdaqIMnk8kRTX2JKwq1Fx7gb2+Jj5Dus8kzvIpKkWOMNU51w==",
+          "dev": true,
+          "requires": {
+            "commander": "2.11.0",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "ultron": {
@@ -13287,6 +11346,39 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
+    "unicode-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+      "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
+      }
     },
     "unique-filename": {
       "version": "1.1.0",
@@ -13407,23 +11499,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        }
       }
     },
     "vm-browserify": {
@@ -13448,15 +11523,13 @@
       "dev": true,
       "requires": {
         "foreachasync": "3.0.0"
-      },
-      "dependencies": {
-        "foreachasync": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-          "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
-          "dev": true
-        }
       }
+    },
+    "walk-back": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+      "dev": true
     },
     "watchpack": {
       "version": "1.4.0",
@@ -13464,9 +11537,30 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
+        "async": "2.6.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "webdav": {
+      "version": "1.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/webdav/-/webdav-1.0.0-rc1.tgz",
+      "integrity": "sha1-UT6nI8EdnqnqGw4ND0TzxoXIS1U=",
+      "requires": {
+        "deepmerge": "1.5.2",
+        "node-fetch": "1.6.3",
+        "xml2js": "0.4.19"
       }
     },
     "webdav-fs": {
@@ -13475,42 +11569,6 @@
       "integrity": "sha1-hOGOGlcIpexOSnljyF1G2+ecFWY=",
       "requires": {
         "webdav": "1.0.0-rc1"
-      },
-      "dependencies": {
-        "deepmerge": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-          "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
-        },
-        "sax": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-        },
-        "webdav": {
-          "version": "1.0.0-rc1",
-          "resolved": "https://registry.npmjs.org/webdav/-/webdav-1.0.0-rc1.tgz",
-          "integrity": "sha1-UT6nI8EdnqnqGw4ND0TzxoXIS1U=",
-          "requires": {
-            "deepmerge": "1.5.2",
-            "node-fetch": "1.6.3",
-            "xml2js": "0.4.19"
-          }
-        },
-        "xml2js": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-          "requires": {
-            "sax": "1.2.4",
-            "xmlbuilder": "9.0.4"
-          }
-        },
-        "xmlbuilder": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-          "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
-        }
       }
     },
     "webpack": {
@@ -13519,11 +11577,11 @@
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
-        "async": "2.5.0",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
+        "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
         "interpret": "1.0.4",
@@ -13533,16 +11591,130 @@
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
         "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
+        "node-libs-browser": "2.1.0",
         "source-map": "0.5.7",
         "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",
-        "webpack-sources": "1.0.1",
+        "webpack-sources": "1.0.2",
         "yargs": "8.0.2"
       },
       "dependencies": {
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
         "supports-color": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -13550,31 +11722,6 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
-            }
           }
         },
         "uglifyjs-webpack-plugin": {
@@ -13585,7 +11732,28 @@
           "requires": {
             "source-map": "0.5.7",
             "uglify-js": "2.8.29",
-            "webpack-sources": "1.0.1"
+            "webpack-sources": "1.0.2"
+          }
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         }
       }
@@ -13612,13 +11780,21 @@
       }
     },
     "webpack-sources": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
+      "integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "which": {
@@ -13643,15 +11819,24 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wordwrapjs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
+      "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
+      "dev": true,
+      "requires": {
+        "array-back": "1.0.4",
+        "typical": "2.6.1"
+      }
     },
     "worker-farm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
-      "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
         "errno": "0.1.4",
@@ -13668,19 +11853,24 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -13716,6 +11906,20 @@
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
@@ -13746,104 +11950,15 @@
       "dev": true
     },
     "yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
         "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
+        "window-size": "0.1.0"
       }
     },
     "yargs-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,6 +1496,11 @@
         "supports-color": "2.0.0"
       }
     },
+    "chardet": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.0.tgz",
+      "integrity": "sha1-C74TVaxE16PtSpJXB8TvcPgZD2w="
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -1539,9 +1544,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "cipher-base": {
@@ -3530,12 +3535,12 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
+        "chardet": "0.4.0",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -5438,7 +5443,7 @@
         "chalk": "1.1.3",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -5471,28 +5476,13 @@
       "dev": true
     },
     "iocane": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/iocane/-/iocane-0.10.0.tgz",
-      "integrity": "sha512-3GD5Xhx92B69V0NBzDPUQAFoR/1HPYG9SUOZti4MTBFFk7N8O9uBx1Tz2fL7z/EnBkTCbAb6HgZZIiC7+X+upA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/iocane/-/iocane-0.10.1.tgz",
+      "integrity": "sha512-fbcBsAxXlXUuxJgGvbIprvdCRNSbcQK/cUvEaTfmfFOkUpZqhx4rNEVu8VYEZzapCSUtb46XizXL6/ttoDlVIQ==",
       "requires": {
-        "debug": "2.3.3",
+        "debug": "3.1.0",
         "hash_file": "0.1.1",
         "pbkdf2": "3.0.14"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-        }
       }
     },
     "ip": {
@@ -5542,7 +5532,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "1.1.2"
       }
     },
     "is-date-object": {
@@ -5973,11 +5963,6 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
-    },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "jsdoc-75lb": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@buttercup/channel-queue": "~0.2.2",
     "clone": "~1.0.2",
-    "debug": "~2.3.3",
+    "debug": "~3.1.0",
     "dropbox-fs": "~0.1.0",
     "eventemitter3": "~2.0.3",
     "fuse.js": "~2.7.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eventemitter3": "~2.0.3",
     "fuse.js": "~2.7.2",
     "gzip-js": "~0.3.2",
-    "iocane": "~0.10.0",
+    "iocane": "~0.10.1",
     "node-fetch": "~1.6.3",
     "opencollective": "~1.0.3",
     "string-hash": "^1.1.3",


### PR DESCRIPTION
Current `debug` version has known vulnerabilities as described [here](https://nodesecurity.io/advisories/534)

I also re-generated `package-lock.json` 