### PR TITLE
Rework references to improve memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6651,9 +6651,9 @@
       "dev": true
     },
     "fuse.js": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.0.tgz",
-      "integrity": "sha512-MagWS1i3kj58BgF9xymo+n2ZiSs9MoyVfxkCcr11+mzMpNEyTDyLtbU3DyrVjHsy0Gkjf58FH1n+TaihylFcIA=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.1.tgz",
+      "integrity": "sha512-+hAS7KYgLXontDh/vqffs7wIBw0ceb9Sx8ywZQhOsiQGcSO5zInGhttWOUYQYlvV/yYMJOacQ129Xs3mP3+oZQ=="
     },
     "gensync": {
       "version": "1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "fast-levenshtein": "^2.0.6",
     "foreachasync": "^5.1.3",
     "form-data": "^3.0.0",
-    "fuse.js": "^6.4.0",
+    "fuse.js": "^6.4.1",
     "global": "^4.4.0",
     "hash.js": "^1.1.7",
     "iocane": "^4.1.0",

--- a/source/core/Entry.ts
+++ b/source/core/Entry.ts
@@ -39,6 +39,7 @@ export default class Entry extends VaultItem {
         const id = generateUUID();
         // Create new entry
         vault.format.createEntry(parentGroupID, id);
+        vault._rebuild();
         return vault.findEntryByID(id);
     }
 
@@ -64,6 +65,10 @@ export default class Entry extends VaultItem {
         }
         // delete it
         this.vault.format.deleteEntry(this.id);
+        const ind = this.vault._entries.indexOf(this);
+        if (ind >= 0) {
+            this.vault._entries.splice(ind, 1);
+        }
         this._cleanUp();
         return true;
     }
@@ -130,7 +135,8 @@ export default class Entry extends VaultItem {
         if (!parentGroup) {
             throw new Error(`No parent group found for entry: ${this.id}`);
         }
-        return new Group(this.vault, parentGroup);
+        const parentID = this.vault.format.getItemID(parentGroup);
+        return this.vault._groups.find(group => group.id === parentID);
     }
 
     /**

--- a/source/core/Group.ts
+++ b/source/core/Group.ts
@@ -205,7 +205,6 @@ export default class Group extends VaultItem {
         if (parentID === "0") return null;
         const parentGroup = this.vault._groups.find(g => g.id === parentID);
         if (!parentGroup) {
-            console.log("PARENT ID", parentID);
             throw new Error(`Failed getting parent Group: No group containing child ID found: ${this.id}`);
         }
         return parentGroup;

--- a/source/core/Group.ts
+++ b/source/core/Group.ts
@@ -209,17 +209,6 @@ export default class Group extends VaultItem {
             throw new Error(`Failed getting parent Group: No group containing child ID found: ${this.id}`);
         }
         return parentGroup;
-        // const topmostGroupIDs = this.vault.getGroups().map(group => group.id);
-        // if (topmostGroupIDs.indexOf(this.id) >= 0) {
-        //     // parent is vault
-        //     return null;
-        // }
-        // const parentGroup = this.vault.format.findGroupContainingGroupID(this.id);
-        // if (parentGroup) {
-        //     const parentID = this.vault.format.getItemID(parentGroup);
-        //     return this.vault._groups.find(group => group.id === parentID);
-        // }
-        // throw new Error(`Failed getting parent Group: No group containing child ID found: ${this.id}`);
     }
 
     /**

--- a/source/core/VaultItem.ts
+++ b/source/core/VaultItem.ts
@@ -29,8 +29,6 @@ export default class VaultItem {
             VaultPermission.Read,
             VaultPermission.Write
         ];
-        this._boundUpdateRefs = this._updateRefs.bind(this);
-        vault.on("formatUpdated", this._boundUpdateRefs);
     }
 
     /**
@@ -102,7 +100,6 @@ export default class VaultItem {
      * @memberof VaultItem
      */
     _cleanUp() {
-        this._vault.off("formatUpdated", this._boundUpdateRefs);
         this._vault = null;
         this._source = null;
     }

--- a/source/core/VaultSource.ts
+++ b/source/core/VaultSource.ts
@@ -595,7 +595,7 @@ export default class VaultSource extends EventEmitter {
         // Reset archive history (without shares)
         const { base } = extractedShares;
         delete extractedShares.base;
-        this.vault.format.clear();
+        this.vault.format.erase();
         this.vault.format.execute(base);
         // Update share payloads
         Object.keys(extractedShares).forEach(shareID => {

--- a/source/io/VaultFormat.ts
+++ b/source/io/VaultFormat.ts
@@ -73,10 +73,6 @@ export default class VaultFormat extends EventEmitter {
         this.source = source;
     }
 
-    clear() {
-        notImplemented();
-    }
-
     cloneEntry(entry: FormatAEntry | FormatBEntry, targetGroupID: GroupID) {
         notImplemented();
     }
@@ -198,6 +194,11 @@ export default class VaultFormat extends EventEmitter {
     }
 
     getItemID(itemSource: FormatAGroup | FormatAEntry | FormatBGroup | FormatBEntry): GroupID | EntryID {
+        notImplemented();
+        return "";
+    }
+
+    getItemParentID(itemSource: FormatAGroup | FormatAEntry | FormatBGroup | FormatBEntry): GroupID | "0" {
         notImplemented();
         return "";
     }

--- a/source/io/VaultFormatA.ts
+++ b/source/io/VaultFormatA.ts
@@ -179,7 +179,7 @@ export default class VaultFormatA extends VaultFormat {
         const newHistoryStaged = VaultFormatA.prepareHistoryForMerge(differences.secondary);
         const base = differences.common;
         const newVault = new Vault(VaultFormatA);
-        newVault.format.clear();
+        newVault.format.erase();
         // merge all history and execute on new vault
         base.concat(newHistoryStaged)
             .concat(newHistoryMain)
@@ -197,15 +197,6 @@ export default class VaultFormatA extends VaultFormat {
         super(source);
         this._history = [];
         this._history.format = VaultFormatID.A;
-    }
-
-    clear() {
-        this._history = [];
-        if (this.source) {
-            for (const key in this.source) {
-                delete this.source[key];
-            }
-        }
     }
 
     cloneEntry(entry: FormatAEntry, targetGroupID: GroupID) {}
@@ -282,6 +273,12 @@ export default class VaultFormatA extends VaultFormat {
                 .addArgument(attribute)
                 .generateCommand()
         );
+    }
+
+    erase() {
+        super.erase();
+        Object.assign(this.source, emptyVault());
+        this.emit("erased");
     }
 
     execute(commandOrCommands: string | Array<string>) {
@@ -406,6 +403,10 @@ export default class VaultFormatA extends VaultFormat {
 
     getItemID(itemSource: FormatAGroup | FormatAEntry): GroupID | EntryID {
         return itemSource.id;
+    }
+
+    getItemParentID(itemSource: FormatAGroup | FormatAEntry): GroupID | "0" {
+        return itemSource.parentID;
     }
 
     getVaultAttributes() {

--- a/source/io/VaultFormatB.ts
+++ b/source/io/VaultFormatB.ts
@@ -181,6 +181,12 @@ export default class VaultFormatB extends VaultFormat {
         this.source.a[attribute].deleted = getTimestamp();
     }
 
+    erase() {
+        super.erase();
+        Object.assign(this.source, emptyVault());
+        this.emit("erased");
+    }
+
     execute(commandOrCommands: string | Array<string>) {
         let command: string;
         if (Array.isArray(commandOrCommands)) {
@@ -295,6 +301,10 @@ export default class VaultFormatB extends VaultFormat {
 
     getItemID(itemSource: FormatBGroup | FormatBEntry): GroupID | EntryID {
         return itemSource.id;
+    }
+
+    getItemParentID(itemSource: FormatBGroup | FormatBEntry): GroupID | "0" {
+        return itemSource.g;
     }
 
     getVaultAttributes() {

--- a/source/io/formatA/Flattener.ts
+++ b/source/io/formatA/Flattener.ts
@@ -84,7 +84,7 @@ export default class Flattener {
             ...history.slice(availableLines) // the existing history minus the flattened portion
         ];
         // clear the system
-        this.format.clear();
+        this.format.erase();
         // replay all history (expensive)
         this.format.execute(newHistory);
         // newHistory.forEach(this.format.execute.bind(this._westley));

--- a/test/integration/core/VaultManager.spec.js
+++ b/test/integration/core/VaultManager.spec.js
@@ -84,7 +84,6 @@ describe("VaultManager", function() {
                 // Save (+ merge)
                 await source.save();
                 // Expect the changes are present
-                console.log(source.vault._groups);
                 const remoteGroup = source.vault.findGroupsByTitle("Remote")[0];
                 const localGroup = source.vault.findGroupsByTitle("Local")[0];
                 expect(remoteGroup).to.be.an.instanceOf(Group, "Remote item should be a group");

--- a/test/integration/core/VaultManager.spec.js
+++ b/test/integration/core/VaultManager.spec.js
@@ -84,10 +84,11 @@ describe("VaultManager", function() {
                 // Save (+ merge)
                 await source.save();
                 // Expect the changes are present
+                console.log(source.vault._groups);
                 const remoteGroup = source.vault.findGroupsByTitle("Remote")[0];
                 const localGroup = source.vault.findGroupsByTitle("Local")[0];
-                expect(remoteGroup).to.be.an.instanceOf(Group);
-                expect(localGroup).to.be.an.instanceOf(Group);
+                expect(remoteGroup).to.be.an.instanceOf(Group, "Remote item should be a group");
+                expect(localGroup).to.be.an.instanceOf(Group, "Local item should be a group");
             });
         });
     });

--- a/test/integration/facades/vault.spec.js
+++ b/test/integration/facades/vault.spec.js
@@ -4,7 +4,6 @@ const {
     Vault,
     VaultFormatA,
     VaultFormatB,
-    consumeGroupFacade,
     consumeVaultFacade,
     createEntryFacade,
     createFieldDescriptor,
@@ -12,7 +11,7 @@ const {
     createVaultFacade
 } = require("../../../dist/index.node.js");
 
-describe("facades/vault", function() {
+describe("Vault facades", function() {
     [
         [VaultFormatA, "A"],
         [VaultFormatB, "B"]
@@ -40,11 +39,12 @@ describe("facades/vault", function() {
             describe("consumeVaultFacade", function() {
                 it("supports deleting entries", function() {
                     const facade = createVaultFacade(this.vault);
-                    const targetEntryIndex = facade.entries.findIndex(entryFacade => entryFacade.id === this.entryA.id);
-                    expect(this.vault.findEntryByID(this.entryA.id)).to.be.an.instanceOf(Entry);
+                    const entryAID = this.entryA.id;
+                    const targetEntryIndex = facade.entries.findIndex(entryFacade => entryFacade.id === entryAID);
+                    expect(this.vault.findEntryByID(entryAID)).to.be.an.instanceOf(Entry);
                     facade.entries.splice(targetEntryIndex, 1);
                     consumeVaultFacade(this.vault, facade);
-                    expect(this.vault.findEntryByID(this.entryA.id)).to.be.null;
+                    expect(this.vault.findEntryByID(entryAID)).to.be.null;
                 });
 
                 it("supports moving entries", function() {

--- a/test/unit/core/Vault.spec.js
+++ b/test/unit/core/Vault.spec.js
@@ -1,4 +1,5 @@
 const { Group, Vault } = require("../../../dist/index.node.js");
+const { expect } = require("chai");
 
 describe("core/Vault", function() {
     it("can be instantiated", function() {
@@ -138,6 +139,25 @@ describe("core/Vault", function() {
         it("returns null if not found", function() {
             const found = this.vault.findGroupByID("");
             expect(found).to.be.null;
+        });
+    });
+
+    describe("findGroupsByTitle", function() {
+        beforeEach(function() {
+            this.vault = new Vault();
+            this.top = this.vault.createGroup("top");
+            this.bottom = this.top.createGroup("bottom");
+        });
+
+        it("gets the correct group", function() {
+            const found = this.vault.findGroupsByTitle("bottom");
+            expect(found).to.have.a.lengthOf(1);
+            expect(found[0].id).to.equal(this.bottom.id);
+        });
+
+        it("returns an empty array if not found", function() {
+            const found = this.vault.findGroupsByTitle("not-real");
+            expect(found).to.have.a.lengthOf(0);
         });
     });
 

--- a/test/unit/io/formatA/VaultComparator.spec.js
+++ b/test/unit/io/formatA/VaultComparator.spec.js
@@ -5,7 +5,7 @@ describe("core/VaultComparator", function() {
     beforeEach(function() {
         this.vault1 = new Vault();
         this.vault2 = new Vault();
-        this.vault2.format.clear();
+        this.vault2.format.erase();
         this.vault2.format.execute(this.vault1.format.history);
     });
 
@@ -13,7 +13,7 @@ describe("core/VaultComparator", function() {
         beforeEach(function() {
             this.vault1 = Vault.createWithDefaults();
             this.vault2 = new Vault();
-            this.vault2.format.clear();
+            this.vault2.format.erase();
             this.vault2.format.execute(this.vault1.format.history);
             this.vault1.createGroup("diff group");
         });
@@ -66,7 +66,7 @@ describe("core/VaultComparator", function() {
 
         it("returns false when no differences exist after modification", function() {
             this.vault1.createGroup("hai");
-            this.vault2.format.clear();
+            this.vault2.format.erase();
             this.vault2.format.execute(this.vault1.format.history);
             const comparator = new VaultComparator(this.vault1, this.vault2);
             expect(comparator.vaultsDiffer()).to.be.false;
@@ -74,7 +74,7 @@ describe("core/VaultComparator", function() {
 
         it("returns true when an archive is out of date", function() {
             this.vault1.createGroup("hai");
-            this.vault2.format.clear();
+            this.vault2.format.erase();
             this.vault2.format.execute(this.vault1.format.history);
             this.vault1.createGroup("hai again");
             const comparator = new VaultComparator(this.vault1, this.vault2);

--- a/test/web/search.spec.js
+++ b/test/web/search.spec.js
@@ -120,10 +120,8 @@ describe("Search", function() {
             it("finds multiple similar results", function() {
                 const results = this.search.searchByURL("https://gmov.edu.au/portal/");
                 expect(results).to.have.lengthOf(2);
-                const titles = results.map(result => result.properties.title);
-                expect(titles).to.contain("Work");
-                expect(titles).to.contain("Work logs");
                 expect(results[0].properties.title).to.equal("Work");
+                expect(results[1].properties.title).to.equal("Work logs");
             });
 
             it("supports ordering", function() {

--- a/test/web/search.spec.js
+++ b/test/web/search.spec.js
@@ -120,8 +120,10 @@ describe("Search", function() {
             it("finds multiple similar results", function() {
                 const results = this.search.searchByURL("https://gmov.edu.au/portal/");
                 expect(results).to.have.lengthOf(2);
+                const titles = results.map(result => result.properties.title);
+                expect(titles).to.contain("Work");
+                expect(titles).to.contain("Work logs");
                 expect(results[0].properties.title).to.equal("Work");
-                expect(results[1].properties.title).to.equal("Work logs");
             });
 
             it("supports ordering", function() {


### PR DESCRIPTION
This PR reworks how Vault/Group/Entry references are handled, in an attempt to improve memory handling and garbage collection.

Fixes #282